### PR TITLE
Add app-level metadata

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+]

--- a/README.md
+++ b/README.md
@@ -21,13 +21,46 @@ end
 
 Then set the format of your logs in production:
 
-```
+```elixir
 # config/prod.exs
 
 config :logger, :console,
   level: :info,
   format: {CeeLogFormatter, :format}
 
+```
+
+## Configuration
+
+You can add metadata to all your requests via config options:
+
+```elixir
+config :cee_log_formatter,
+  metadata: [
+    app_name: "my-app",
+    arbitrary_mfa: {MyMod, :some_func, [:arg1, :arg2]}
+  ]
+```
+
+The `metadata` config takes a keyword list. If the value is a string, it is used directly in the
+log output. If the value is a 3-element tuple, it is expected to be a `{Module, function,
+argument-list}`, which is called for every log line to get some current value. If the value
+returned from the MFA is not a string, it is ignored.
+
+For instance, you could have the current unix timestamp added to the log with:
+
+```elixir
+defmodule TimestampLog do
+  def current() do
+    "#{:os.system_time(:second)}"
+  end
+end
+
+# in config.exs
+config :cee_log_formatter,
+  metadata: [
+    timestamp: {TimestampLog, :current, []}
+  ]
 ```
 
 You should also use the [PlugLoggerJson](https://github.com/bleacherreport/plug_logger_json)

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ For instance, you could have the current unix timestamp added to the log with:
 
 ```elixir
 defmodule TimestampLog do
-  def current() do
-    "#{:os.system_time(:second)}"
+  def current(resolution) do
+    "#{:os.system_time(resolution)}"
   end
 end
 
 # in config.exs
 config :cee_log_formatter,
   metadata: [
-    timestamp: {TimestampLog, :current, []}
+    timestamp: {TimestampLog, :current, [:second]}
   ]
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule CeeLogFormatter.Mixfile do
 
   defp deps do
     [
-      poison: ">= 0.1.0"
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:poison, ">= 0.1.0"},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,13 +4,13 @@ defmodule CeeLogFormatter.Mixfile do
   def project do
     [
       app: :cee_log_formatter,
-      build_embedded: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
       deps: deps(),
       description: description(),
       elixir: "~> 1.5",
       package: package(),
-      start_permanent: Mix.env == :prod,
-      version: "0.1.0",
+      start_permanent: Mix.env() == :prod,
+      version: "0.1.0"
     ]
   end
 
@@ -30,14 +30,14 @@ defmodule CeeLogFormatter.Mixfile do
       files: ["lib", "mix.exs", "README.md"],
       maintainers: ["Donald Plummer"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/avvo/cee_log_formatter"},
+      links: %{"GitHub" => "https://github.com/avvo/cee_log_formatter"}
     ]
   end
 
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:poison, ">= 0.1.0"},
+      {:poison, ">= 0.1.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}
+%{"earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}

--- a/test/cee_log_formatter_test.exs
+++ b/test/cee_log_formatter_test.exs
@@ -1,6 +1,10 @@
 defmodule CeeLogFormatterTest do
   use ExUnit.Case
 
+  def test_fun(word) do
+    "the word is #{word}"
+  end
+
   #timestamp = {{2014, 12, 30}, {12, 6, 30, 100}}
 
   test "formats raw messages" do
@@ -15,5 +19,39 @@ defmodule CeeLogFormatterTest do
   test "formats a map message" do
     data = %{"foo" => "bar", "baz" => 1}
     assert CeeLogFormatter.format(:info, data, nil, []) == ~s(@cee: {"foo":"bar","baz":1,"severity":"info"}\n)
+  end
+
+  test "includes metadata from config" do
+    with_env_config([metadata: [foo: "meta"]], fn ->
+      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"meta"}\n)
+    end)
+  end
+
+  test "includes multiple metadatas from config" do
+    with_env_config([metadata: [foo: "meta", cat: "meow", dog: "bark"]], fn ->
+      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"meta","dog":"bark","cat":"meow"}\n)
+    end)
+  end
+
+  test "does not error with non-string values" do
+    with_env_config([metadata: [foo: 1]], fn ->
+      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello"}\n)
+    end)
+  end
+
+  test "calls mfas for values" do
+    with_env_config([metadata: [foo: {CeeLogFormatterTest, :test_fun, ["bird"]}]], fn ->
+      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"the word is bird"}\n)
+    end)
+  end
+
+  def with_env_config([metadata: metadata], func) do
+    original_conf = Application.get_env(:cee_log_formatter, :metadata)
+    Application.put_env(:cee_log_formatter, :metadata, metadata)
+    try do
+      func.()
+    after
+      Application.put_env(:cee_log_formatter, :metadata, original_conf)
+    end
   end
 end

--- a/test/cee_log_formatter_test.exs
+++ b/test/cee_log_formatter_test.exs
@@ -5,49 +5,59 @@ defmodule CeeLogFormatterTest do
     "the word is #{word}"
   end
 
-  #timestamp = {{2014, 12, 30}, {12, 6, 30, 100}}
+  # timestamp = {{2014, 12, 30}, {12, 6, 30, 100}}
 
   test "formats raw messages" do
-    assert CeeLogFormatter.format(:info, "hello world", nil, []) == ~s(@cee: {"severity":"info","msg":"hello world"}\n)
+    assert CeeLogFormatter.format(:info, "hello world", nil, []) ==
+             ~s(@cee: {"severity":"info","msg":"hello world"}\n)
   end
 
   test "formats a json encoded message" do
     data = ~s({"foo":"bar","baz":1})
-    assert CeeLogFormatter.format(:info, data, nil, []) == ~s(@cee: {"foo":"bar","baz":1,"severity":"info"}\n)
+
+    assert CeeLogFormatter.format(:info, data, nil, []) ==
+             ~s(@cee: {"foo":"bar","baz":1,"severity":"info"}\n)
   end
 
   test "formats a map message" do
     data = %{"foo" => "bar", "baz" => 1}
-    assert CeeLogFormatter.format(:info, data, nil, []) == ~s(@cee: {"foo":"bar","baz":1,"severity":"info"}\n)
+
+    assert CeeLogFormatter.format(:info, data, nil, []) ==
+             ~s(@cee: {"foo":"bar","baz":1,"severity":"info"}\n)
   end
 
   test "includes metadata from config" do
     with_env_config([metadata: [foo: "meta"]], fn ->
-      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"meta"}\n)
+      assert CeeLogFormatter.format(:info, "hello", nil, []) ==
+               ~s(@cee: {"severity":"info","msg":"hello","foo":"meta"}\n)
     end)
   end
 
   test "includes multiple metadatas from config" do
     with_env_config([metadata: [foo: "meta", cat: "meow", dog: "bark"]], fn ->
-      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"meta","dog":"bark","cat":"meow"}\n)
+      assert CeeLogFormatter.format(:info, "hello", nil, []) ==
+               ~s(@cee: {"severity":"info","msg":"hello","foo":"meta","dog":"bark","cat":"meow"}\n)
     end)
   end
 
   test "does not error with non-string values" do
     with_env_config([metadata: [foo: 1]], fn ->
-      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello"}\n)
+      assert CeeLogFormatter.format(:info, "hello", nil, []) ==
+               ~s(@cee: {"severity":"info","msg":"hello"}\n)
     end)
   end
 
   test "calls mfas for values" do
     with_env_config([metadata: [foo: {CeeLogFormatterTest, :test_fun, ["bird"]}]], fn ->
-      assert CeeLogFormatter.format(:info, "hello", nil, []) == ~s(@cee: {"severity":"info","msg":"hello","foo":"the word is bird"}\n)
+      assert CeeLogFormatter.format(:info, "hello", nil, []) ==
+               ~s(@cee: {"severity":"info","msg":"hello","foo":"the word is bird"}\n)
     end)
   end
 
   def with_env_config([metadata: metadata], func) do
     original_conf = Application.get_env(:cee_log_formatter, :metadata)
     Application.put_env(:cee_log_formatter, :metadata, metadata)
+
     try do
       func.()
     after


### PR DESCRIPTION
So we can have the app-name in all the log lines:

```elixir
config :cee_log_formatter,
  metadata: [
    app_name: "my-app-name"
  ]
```

This is different from `Logger.metadata` in that this is app-wide instead of Process specific.