### PR TITLE
Make Poison optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  test:
+    working_directory: /srv/cee_log_formatter
+
+    docker:
+      - image: avvo/elixir:1.10.2-otp-22-alpine-3.11
+
+    steps:
+      - checkout
+
+      - run: mix do deps.get
+
+      - run: mix test
+
+      - store_test_results:
+          path: ~/cee_log_formatter/_build/test/lib/cee_log_formatter/
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+    - test:
+        context: org-global

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ config :cee_log_formatter,
   prefix: ""
 ```
 
+By default CeeLogFormatter will try to use Poison to encode and decode JSON, but you can configure it to any other json library that implements `encode!()` and `decode!()` callbacks:
+
+```elixir
+config :cee_log_formatter, :json_library, Jason
+```
 
 You can add metadata to all your requests via config options:
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,12 +10,12 @@ defmodule CeeLogFormatter.Mixfile do
       elixir: "~> 1.4",
       package: package(),
       start_permanent: Mix.env() == :prod,
-      version: "0.2.2"
+      version: "0.2.3"
     ]
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger], env: [json_library: Poison]]
   end
 
   defp description do
@@ -37,7 +37,7 @@ defmodule CeeLogFormatter.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:poison, ">= 0.1.0"}
+      {:poison, ">= 0.1.0", optional: true}
     ]
   end
 end


### PR DESCRIPTION
`Poison` is not standard de-facto JSON lib for elixir anymore. [`Jason`](https://hex.pm/packages/jason) is the new `Poison`.

And our new apps use Jason by default, and we don't want to pollute dependencies with Poison.

Hence, I added `json_library` application environment variable and set its default value to `Poison` so that users can configure json encoders.

UPD: Added CircleCI test job